### PR TITLE
Fix typo in tests/src

### DIFF
--- a/platform/minilogue-xd/osc/tests/src/bipolar.cpp
+++ b/platform/minilogue-xd/osc/tests/src/bipolar.cpp
@@ -132,7 +132,7 @@ void OSC_PARAM(uint16_t index, uint16_t value)
   case k_user_osc_param_shape:
     s_state.dist = 0.3f * valf;
     break;
-  case k_user_osc_param_shift_shape:
+  case k_user_osc_param_shiftshape:
     s_state.drive = 1.f + valf; 
     break;
   default:

--- a/platform/minilogue-xd/osc/tests/src/maxsize.cpp
+++ b/platform/minilogue-xd/osc/tests/src/maxsize.cpp
@@ -146,17 +146,17 @@ void OSC_PARAM(uint16_t index, uint16_t value)
   const float valf = param_val_to_f32(value);
   
   switch (index) {
-  case k_osc_param_id1:
-  case k_osc_param_id2:
-  case k_osc_param_id3:
-  case k_osc_param_id4:
-  case k_osc_param_id5:
-  case k_osc_param_id6:
+  case k_user_osc_param_id1:
+  case k_user_osc_param_id2:
+  case k_user_osc_param_id3:
+  case k_user_osc_param_id4:
+  case k_user_osc_param_id5:
+  case k_user_osc_param_id6:
     break;
-  case k_osc_param_shape:
+  case k_user_osc_param_shape:
     s_state.dist = 0.3f * valf;
     break;
-  case k_osc_param_shiftshape:
+  case k_user_osc_param_shiftshape:
     s_state.drive = 1.f + valf; 
     break;
   default:

--- a/platform/nutekt-digital/osc/tests/src/bipolar.cpp
+++ b/platform/nutekt-digital/osc/tests/src/bipolar.cpp
@@ -132,7 +132,7 @@ void OSC_PARAM(uint16_t index, uint16_t value)
   case k_user_osc_param_shape:
     s_state.dist = 0.3f * valf;
     break;
-  case k_user_osc_param_shift_shape:
+  case k_user_osc_param_shiftshape:
     s_state.drive = 1.f + valf; 
     break;
   default:

--- a/platform/nutekt-digital/osc/tests/src/maxsize.cpp
+++ b/platform/nutekt-digital/osc/tests/src/maxsize.cpp
@@ -146,17 +146,17 @@ void OSC_PARAM(uint16_t index, uint16_t value)
   const float valf = param_val_to_f32(value);
   
   switch (index) {
-  case k_osc_param_id1:
-  case k_osc_param_id2:
-  case k_osc_param_id3:
-  case k_osc_param_id4:
-  case k_osc_param_id5:
-  case k_osc_param_id6:
+  case k_user_osc_param_id1:
+  case k_user_osc_param_id2:
+  case k_user_osc_param_id3:
+  case k_user_osc_param_id4:
+  case k_user_osc_param_id5:
+  case k_user_osc_param_id6:
     break;
-  case k_osc_param_shape:
+  case k_user_osc_param_shape:
     s_state.dist = 0.3f * valf;
     break;
-  case k_osc_param_shiftshape:
+  case k_user_osc_param_shiftshape:
     s_state.drive = 1.f + valf; 
     break;
   default:

--- a/platform/prologue/osc/tests/src/bipolar.cpp
+++ b/platform/prologue/osc/tests/src/bipolar.cpp
@@ -132,7 +132,7 @@ void OSC_PARAM(uint16_t index, uint16_t value)
   case k_user_osc_param_shape:
     s_state.dist = 0.3f * valf;
     break;
-  case k_user_osc_param_shift_shape:
+  case k_user_osc_param_shiftshape:
     s_state.drive = 1.f + valf; 
     break;
   default:

--- a/platform/prologue/osc/tests/src/maxsize.cpp
+++ b/platform/prologue/osc/tests/src/maxsize.cpp
@@ -146,17 +146,17 @@ void OSC_PARAM(uint16_t index, uint16_t value)
   const float valf = param_val_to_f32(value);
   
   switch (index) {
-  case k_osc_param_id1:
-  case k_osc_param_id2:
-  case k_osc_param_id3:
-  case k_osc_param_id4:
-  case k_osc_param_id5:
-  case k_osc_param_id6:
+  case k_user_osc_param_id1:
+  case k_user_osc_param_id2:
+  case k_user_osc_param_id3:
+  case k_user_osc_param_id4:
+  case k_user_osc_param_id5:
+  case k_user_osc_param_id6:
     break;
-  case k_osc_param_shape:
+  case k_user_osc_param_shape:
     s_state.dist = 0.3f * valf;
     break;
-  case k_osc_param_shiftshape:
+  case k_user_osc_param_shiftshape:
     s_state.drive = 1.f + valf; 
     break;
   default:


### PR DESCRIPTION
There ware typo, maybe a mistake when cloning on bipolar.cpp x 3 and maxsize.cpp x 3 in "platform/*/osc/tests/src".