### PR TITLE
Add more fils to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,11 @@ tools/emscripten/emsdk
 *.dSYM/
 *.su
 
+# Temporary files
+.sudo_as_admin_successful
+.hushlogin
+.drumlogue.env_backup
+
+# WSL
+.profile
+.bash_history


### PR DESCRIPTION
It seems the build scripts use several files for representing the state, which don't need to be committed. Besides, using WSL creates some files. I think it's a good idea to exclude them by default.