### PR TITLE
CHSynth, a free chord synth for the Drumlogue

### DIFF
--- a/04_synth_index.md
+++ b/04_synth_index.md
@@ -13,4 +13,5 @@ _Note: Additions, corrections, broken links? Let us know at logue-sdk@korg.co.jp
 | Name | Developer | Description | Platforms | |
 | Nano | Sinevibes |             | drum | built-in |
 | [Resonator](https://www.icemoonprison.com/blog/?p=780) | Deborah Pickett | Karplus-Strong resonator synth | drum | free |
+| [CHSynth](https://ctrl-alt-delete.co.uk/wp/free-korg-drumlogue-synth/) | CtrlAltDelete | Chord Synth | drum | free |
 

--- a/04_synth_index_ja.md
+++ b/04_synth_index_ja.md
@@ -14,4 +14,5 @@ _Note: 追加,訂正，リンク切れについては logue-sdk@korg.co.jp ま�
 | 名前 | 開発者 | 備考 | プラットフォーム | |
 | Nano | Sinevibes |             | drum | 内蔵 |
 | [Resonator](https://www.icemoonprison.com/blog/?p=780) | Deborah Pickett | Karplus-Strong resonator synth | drum | 無料 |
+| [CHSynth](https://ctrl-alt-delete.co.uk/wp/free-korg-drumlogue-synth/) | CtrlAltDelete | Chord Synth | drum | 無料 |
 


### PR DESCRIPTION
This is a two oscillator mono synth for the Korg Drumlogue. 

Sine, Triangle, Saw, Square, Super-Saw and noise waves. 

Amplifier Envelope.

Modulation Envelope.

Twelve filter types.

Pitch and cutoff modulation.

The ability to set gate length to avoid having to tie steps together in the sequencer.

It has a quantiser and chord system built in where you choose the key, scale and shape of the chord. The idea is you can stay with the same shape and change the root note in order to play the chords in the key.
So for example if you Choose C, Major and 135 you would get the following chords for this sequenced data:

A-->A Minor
B-->B Diminished
C-->C Major
D-->D Minor
E-->E Minor 
F-->F Major 
G-->G Major

The chord system also has a 5 note Unison mode.