### PR TITLE
[nts-1_mkii] fixed incorrect parameter type.

### DIFF
--- a/platform/nts-1_mkii/dummy-osc/osc.h
+++ b/platform/nts-1_mkii/dummy-osc/osc.h
@@ -252,8 +252,8 @@ class Osc {
   inline void AllNoteOff() {
   }
 
-  inline void PitchBend(uint8_t bend) {
-    (uint8_t)bend;
+  inline void PitchBend(uint16_t bend) {
+    (uint16_t)bend;
   }
 
   inline void ChannelPressure(uint8_t press) {

--- a/platform/nts-1_mkii/waves/waves.h
+++ b/platform/nts-1_mkii/waves/waves.h
@@ -434,8 +434,8 @@ public:
   inline void AllNoteOff() {
   }
 
-  inline void PitchBend(uint8_t bend) {
-    (uint8_t)bend;
+  inline void PitchBend(uint16_t bend) {
+    (uint16_t)bend;
   }
 
   inline void ChannelPressure(uint8_t press) {


### PR DESCRIPTION
This PR fixes the incorrect parameter type of `PitchBend().`