### PR TITLE
Added alternative developer ID

### DIFF
--- a/developer_ids.md
+++ b/developer_ids.md
@@ -27,6 +27,7 @@
  | --- | --- | 
  | 0x53564253 ('SVBS') | [Sinevibes](https://sinevib.es) |
  | 0x656B7544 ('ekuD') | [Oleg Burdaev](https://github.com/dukesrg) |
+ | 0x44756B65 ('Duke') | [Oleg Burdaev](https://github.com/dukesrg) |
  | 0x45444F55 ('EDOU') | [Edouard Digital](https://edouard.digital) |
  | 0x434E5452 ('CNTR') | [centrevillage](https://centrevillage.net) |
  | 0x65676773 ('eggs') | [hammondeggsmusic](https://hammondeggsmusic.ca) |


### PR DESCRIPTION
To align with the KORG Kontrol Editor developer field byte order. 