### PR TITLE
Minor changes to waves and dummy-osc

### DIFF
--- a/platform/nts-1_mkii/dummy-osc/osc.h
+++ b/platform/nts-1_mkii/dummy-osc/osc.h
@@ -150,12 +150,21 @@ class Osc {
 
     // Caching current parameter values. Consider interpolating sensitive parameters.
     // const Params p = params_;
+
+    // get osc pitch from context
+    const unit_runtime_osc_context_t *ctxt = static_cast<const unit_runtime_osc_context_t *>(runtime_desc_.hooks.runtime_context);
+    float w0 = osc_w0f_for_note((ctxt->pitch)>>8, ctxt->pitch & 0xFF);
+    float lfo = q31_to_f32(ctxt->shape_lfo); // TODO: Apply shape_lfo to the shape parameter
     
     for (; out_p != out_e; in_p += 2, out_p += 1) {
       // Process/generate samples here
       
-      // Note: this is a dummy unit only to demonstrate APIs, only outputting silence.
-      *out_p = 0.f; // sample
+      // update oscillator phase
+      w += w0;
+      w = modff(w, nullptr); // take fractional part to prevent overflow
+
+      // Note: this is a dummy unit only to demonstrate APIs, only outputting sin wave
+      *out_p = osc_sinf(w);
     }
   }
 
@@ -280,6 +289,8 @@ class Osc {
   unit_runtime_desc_t runtime_desc_;
 
   Params params_;
+
+  float w{0.f}; // phasor in [0.0,1.0)
 
   /*===========================================================================*/
   /* Private Methods. */

--- a/platform/nts-1_mkii/waves/waves.h
+++ b/platform/nts-1_mkii/waves/waves.h
@@ -420,10 +420,7 @@ public:
 
   inline void NoteOn(uint8_t note, uint8_t velo) {
     (void)velo;
-    
-    // Schedule phase reset
-    state_.flags.fetch_or(State::k_flag_reset);
-    
+
     // TODO: should we still fully rely on osc context pitch?
   }
 
@@ -432,6 +429,8 @@ public:
   }
 
   inline void AllNoteOff() {
+    // Schedule phase reset
+    state_.flags.fetch_or(State::k_flag_reset);
   }
 
   inline void PitchBend(uint8_t bend) {


### PR DESCRIPTION
wavesはNoteOnでphase resetするため、NTS-1 MK2で横スライドするとクリックしてしまいます。
phase resetをAllNoteOffに移動すると解消します。

また、サイン波を出力するdummy oscを作ってみました。これでユーザーも作りやすくなると思います。
[再ビルドしたunit](https://drive.google.com/drive/folders/1SBe0vAZY_N-pZycoIb8UpPDG5Wp8hzJ3?usp=sharing)も確認してください。