### PR TITLE
Fixed microKORG2 units fixed parameter numbers

### DIFF
--- a/platform/microkorg2/common/unit_delfx.h
+++ b/platform/microkorg2/common/unit_delfx.h
@@ -55,10 +55,7 @@ extern "C" {
 
   /** Exposed parameters with fixed/direct UI controls. */
   enum {
-    k_unit_delfx_fixed_param_time = 0,
-    k_unit_delfx_fixed_param_depth,
-    k_unit_delfx_fixed_param_mix,
-    k_num_unit_delfx_fixed_param_id
+    k_num_unit_delfx_fixed_param_id = 0
   };
 
 #define UNIT_DELFX_MAX_PARAM_COUNT (8)

--- a/platform/microkorg2/common/unit_modfx.h
+++ b/platform/microkorg2/common/unit_modfx.h
@@ -55,9 +55,7 @@ extern "C" {
 
   /** Exposed parameters with fixed/direct UI controls. */
   enum {
-    k_unit_modfx_fixed_param_time = 0,
-    k_unit_modfx_fixed_param_depth,
-    k_num_unit_modfx_fixed_param_id
+    k_num_unit_modfx_fixed_param_id = 0
   };
 
 #define UNIT_MODFX_MAX_PARAM_COUNT (8)

--- a/platform/microkorg2/common/unit_osc.h
+++ b/platform/microkorg2/common/unit_osc.h
@@ -54,7 +54,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  
+
+  /** Exposed parameters with fixed/direct UI controls. */
+  enum {
+    k_num_unit_osc_fixed_param_id = 0
+  };
+
   #define OSC_MEMORY_SIZE_BYTES 0x2000
   #define OSC_MEMORY_SIZE (OSC_MEMORY_SIZE_BYTES >> 2) // assumes 32 bit data type
   #define UNIT_OSC_MAX_PARAM_COUNT (13)

--- a/platform/microkorg2/common/unit_revfx.h
+++ b/platform/microkorg2/common/unit_revfx.h
@@ -55,10 +55,7 @@ extern "C" {
 
   /** Exposed parameters with fixed/direct UI controls. */
   enum {
-    k_unit_revfx_fixed_param_time = 0,
-    k_unit_revfx_fixed_param_depth,
-    k_unit_revfx_fixed_param_mix,
-    k_num_unit_revfx_fixed_param_id
+    k_num_unit_revfx_fixed_param_id = 0
   };
 
 #define UNIT_REVFX_MAX_PARAM_COUNT (8)


### PR DESCRIPTION
mK2 have no fixed unit params. Please keep for compatibility.