### PR TITLE
fix(mkmk2samples): iterate sources in samples based on mod source count

### DIFF
--- a/platform/microkorg2/vox/vox.h
+++ b/platform/microkorg2/vox/vox.h
@@ -378,7 +378,7 @@ public:
 
         for(int voice = 0; voice < ctxt->voiceLimit; voice+=4)
         {
-          for(int modDest = 0; modDest < kNumModDest; modDest++)
+          for(int modDest = 0; modDest < kNumMk2ModSrc; modDest++)
           {
             float * curr = dests[modDest];
             float32x4_t currentValue = f32x4_ld(&curr[voice]);

--- a/platform/microkorg2/waves/waves.h
+++ b/platform/microkorg2/waves/waves.h
@@ -377,7 +377,7 @@ public:
         float * shapeMod = state_.shapeMod;
         for(int voice = 0; voice < ctxt->voiceLimit; voice+=4)
         {
-          for(int modDest = 0; modDest < kNumModDest; modDest++)
+          for(int modDest = 0; modDest < kNumMk2ModSrc; modDest++)
           {
             if(index[modDest] != kModDestShape) continue;
 


### PR DESCRIPTION
Changes samples for Microkorg2 to iterating based on mod source count (6).
In vox and waves samples message kMk2PlatformExclusiveModData we're iterating the mod sources based on kNumModDest. That probably works for Vox because it has 6 mod destinations (same number as mod sources or slots), but in Waves that should cause only slot 1 to work (if I'm reading this right) as it has only 1 mod destination.

This could also cause some implementer grief when using more than 6 mod destinations - kNumMk2ModDest is defined as 10, I but couldn't find anything about number of allowed mod destinations