### PR TITLE
Add developer ID 'rgrv' for Gerard Braad, project 'Regrooved'

### DIFF
--- a/developer_ids.md
+++ b/developer_ids.md
@@ -41,3 +41,4 @@
  | 0x696b7556 ('Vuki') | [Greg Vuki](https://multimed.org/~greg/) |
  | 0x666d6f64 ('fmod') | [Frostmod Audio](https://github.com/frostmod) |
  | 0x6a504952 ('jPIR') | [Joerg Piringer](https://joerg.piringer.net/nts3) |
+ | 0x72677276 ('rgrv') | [Gerard Braad](https://music.gbraad.nl/logue/) |


### PR DESCRIPTION
This points to https://music.gbraad.nl/logue/ that will be added later.