### PR TITLE
Fix run_cmd for non-interactive executions

### DIFF
--- a/docker/run_cmd.sh
+++ b/docker/run_cmd.sh
@@ -123,5 +123,9 @@ if [ -z "${CMD}" ]; then
     echo "[Err] No command specified: '${CMD}'" 1>&2
     exit 2
 fi
+DOCKER_OPTS=()
+if [ -t 0 ]; then
+    DOCKER_OPTS+=("-it")
+fi
 
-docker run --rm -v "${PLATFORM_PATH}:/workspace" -h logue-sdk -it ${IMAGE_NAME}:${IMAGE_VERSION} /app/cmd_entry ${CMD}
+docker run --rm -v "${PLATFORM_PATH}:/workspace" -h logue-sdk "${DOCKER_OPTS[@]}" ${IMAGE_NAME}:${IMAGE_VERSION} /app/cmd_entry ${CMD}


### PR DESCRIPTION
The `-i` (`--interactive`) and `-t` (`--tty`) flags to `docker run` do not work if it isn't running in a terminal. Only pass these flags when `stdin` is a terminal.