### PR TITLE
Add developer ID for Daniel Majid

### DIFF
--- a/developer_ids.md
+++ b/developer_ids.md
@@ -45,3 +45,4 @@
  | 0x72677276 ('rgrv') | [Gerard Braad](https://music.gbraad.nl/logue/) |
  | 0x4541524C ('EARL') | [Earl of FX](https://github.com/earlofFX) |
  | 0x73726373 ('srcs') | [alternate sources](https://github.com/alternatesources) |
+ | 0x4D616A69 ('Maji') | [Daniel Majid](https://github.com/DanielMajid) |


### PR DESCRIPTION
Adding developer ID for Daniel Majid. Will add specific project listings to the other indexes shortly.