### PR TITLE
Add new developer ID for sZXZ

### DIFF
--- a/developer_ids.md
+++ b/developer_ids.md
@@ -47,3 +47,4 @@
  | 0x73726373 ('srcs') | [alternate sources](https://github.com/alternatesources) |
  | 0x4D616A69 ('Maji') | [Daniel Majid](https://github.com/DanielMajid) |
  | 0x6a736f6e ('json') | [Jason Moore](https://github.com/casconed) |
+ | 0x735A585A ('sZXZ') | [sZXZ](https://github.com/sZXZ) |


### PR DESCRIPTION
I uploaded several nts3 things under this dev_id
https://szxz.gumroad.com/l/noise
https://szxz.gumroad.com/l/arp
https://szxz.gumroad.com/l/drum
https://szxz.gumroad.com/l/granular
https://szxz.gumroad.com/l/bass